### PR TITLE
When cleaning try to skip snapshots we didn't create

### DIFF
--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -52,7 +52,7 @@ class Cleaner(object):
         # Loading snapshots
         snapshot_dict = []
         for snapshot in snapshots:
-            if re.match('^\d{8}$', snapshot ) is not None:
+            if re.match('^(\d{4})(1[0-2]|0[1-9])(0[1-9]|[1-2]\d|3[0-1])$', snapshot ) is not None:
                 snapshot_dict.append({'name': snapshot,
                                       'time': datetime.strptime(snapshot, '%Y%m%d'),
                                       'age': (today - datetime.strptime(snapshot, '%Y%m%d')).days})


### PR DESCRIPTION
As mentioned in issue #10 we skip entries we could never parse as dates (and are probably custom snapshots) by testing the snapshot name for the format YYYYMMDD.
