### PR TITLE
Fix missing helper module

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,6 +17,7 @@ package() {
     mkdir -p "$pkgdir/usr/lib/zfs-snap-manager/"
     install -D -m644 "scripts/clean.py" "$pkgdir/usr/lib/zfs-snap-manager/clean.py"
     install -D -m644 "scripts/zfs.py" "$pkgdir/usr/lib/zfs-snap-manager/zfs.py"
+    install -D -m644 "scripts/helper.py" "$pkgdir/usr/lib/zfs-snap-manager/helper.py"
     install -D -m755 "scripts/manager.py" "$pkgdir/usr/lib/zfs-snap-manager/manager.py"
     install -D -m644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
     install -D -m644 "system/zfs-snap-manager.service" "${pkgdir}/usr/lib/systemd/system/zfs-snap-manager.service"


### PR DESCRIPTION
`helper.py` was missing.

```
Sep 08 19:34:15 xyz manager.py[11979]: Traceback (most recent call last):
Sep 08 19:34:15 xyz manager.py[11979]: File "/usr/lib/zfs-snap-manager/manager.py", line 33, in <module>
Sep 08 19:34:15 xyz manager.py[11979]: from zfs import ZFS
Sep 08 19:34:15 xyz manager.py[11979]: File "/usr/lib/zfs-snap-manager/zfs.py", line 25, in <module>
Sep 08 19:34:15 xyz manager.py[11979]: from helper import Helper
Sep 08 19:34:15 xyz manager.py[11979]: ImportError: No module named helper
```
