### PR TITLE
Add optional compression flag to replication settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Examples
     replicate_endpoint = ssh -p 2345 my.remote.server.org
     replicate_target = zpool/backups/zroot
     schema = 7d3w11m5y
+    compression = gzip
 
     [zpool/data]
     mountpoint = /mnt/data
@@ -69,6 +70,7 @@ A summary of the different options:
 * replicate_endpoint: Can be left empty if replicating on localhost (e.g. copying snapshots to other pool). Should be omitted if no replication is required.
 * replicate_target: The target to which the snapshots should be send. Should be omitted if no replication is required or a replication_source is specified.
 * replicate_source: The source from which to pull the snapshots to receive onto the local dataset. Should be omitted if no replication is required or a replication_target is specified.
+* compression: Indicates the compression program to pipe remote replicated snapshots through (for use in low-bandwidth setups.) The compression utility should accept standard compression flags (`-c` for standard output, `-d` for decompress.)
 * schema: In case the snapshots should be cleaned, this is the schema the manager will use to clean.
 * preexec: A command that will be executed, before snapshot/replication. Should be omitted if nothing should be executed
 * postexec: A command that will be executed, after snapshot/replication,  but before the cleanup. Should be omitted if nothing should be executed

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -137,7 +137,7 @@ class Manager(object):
                                             # There is a snapshot on this host that is not yet on the other side.
                                             size = ZFS.get_size(dataset, previous_snapshot, snapshot)
                                             Manager.logger.info('  {0}@{1} > {0}@{2} ({3})'.format(dataset, previous_snapshot, snapshot, size))
-                                            ZFS.replicate(dataset, previous_snapshot, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push')
+                                            ZFS.replicate(dataset, previous_snapshot, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'])
                                             previous_snapshot = snapshot
                                 else:
                                     for snapshot in remote_snapshots[remote_dataset]:
@@ -206,7 +206,7 @@ class Manager(object):
                                                       if config.has_option(dataset, 'replicate_target') else None,
                                                       'source': config.get(dataset, 'replicate_source')
                                                       if config.has_option(dataset, 'replicate_source') else None,
-                                                      'compression': config.get(dataset), 'compression')
+                                                      'compression': config.get(dataset, 'compression')
                                                       if config.has_option(dataset, 'compression') else None}
         except Exception as ex:
             Manager.logger.error('Exception while parsing configuration file: {0}'.format(str(ex)))

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -205,7 +205,9 @@ class Manager(object):
                                                       'target': config.get(dataset, 'replicate_target')
                                                       if config.has_option(dataset, 'replicate_target') else None,
                                                       'source': config.get(dataset, 'replicate_source')
-                                                      if config.has_option(dataset, 'replicate_source') else None}
+                                                      if config.has_option(dataset, 'replicate_source') else None,
+                                                      'compression': config.get(dataset), 'compression')
+                                                      if config.has_option(dataset, 'compression') else None}
         except Exception as ex:
             Manager.logger.error('Exception while parsing configuration file: {0}'.format(str(ex)))
 

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -148,7 +148,7 @@ class Manager(object):
                                             # There is a remote snapshot that is not yet on the local host.
                                             size = ZFS.get_size(remote_dataset, previous_snapshot, snapshot, replicate_settings['endpoint'])
                                             Manager.logger.info('  {0}@{1} > {0}@{2} ({3})'.format(remote_dataset, previous_snapshot, snapshot, size))
-                                            ZFS.replicate(remote_dataset, previous_snapshot, snapshot, dataset, replicate_settings['endpoint'], direction='pull')
+                                            ZFS.replicate(remote_dataset, previous_snapshot, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'])
                                             previous_snapshot = snapshot
                             elif push is True and len(local_snapshots) > 0:
                                 # No common snapshot
@@ -157,7 +157,7 @@ class Manager(object):
                                     snapshot = local_snapshots[-1]
                                     size = ZFS.get_size(dataset, None, snapshot)
                                     Manager.logger.info('  {0}@         > {0}@{1} ({2})'.format(dataset, snapshot, size))
-                                    ZFS.replicate(dataset, None, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push')
+                                    ZFS.replicate(dataset, None, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'])
                             elif push is False and remote_dataset in remote_snapshots and len(remote_snapshots[remote_dataset]) > 0:
                                 # No common snapshot
                                 if len(local_snapshots) == 0:
@@ -165,7 +165,7 @@ class Manager(object):
                                     snapshot = remote_snapshots[remote_dataset][-1]
                                     size = ZFS.get_size(remote_dataset, None, snapshot, replicate_settings['endpoint'])
                                     Manager.logger.info('  {0}@         > {0}@{1} ({2})'.format(remote_dataset, snapshot, size))
-                                    ZFS.replicate(remote_dataset, None, snapshot, dataset, replicate_settings['endpoint'], direction='pull')
+                                    ZFS.replicate(remote_dataset, None, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'])
                             Manager.logger.info('Replicating {0} complete'.format(dataset))
 
                         # Post execution command

--- a/scripts/zfs.py
+++ b/scripts/zfs.py
@@ -79,7 +79,7 @@ class ZFS(object):
         Helper.run_command(command, '/')
 
     @staticmethod
-    def replicate(dataset, base_snapshot, last_snapshot, target, endpoint='', direction='push'):
+    def replicate(dataset, base_snapshot, last_snapshot, target, endpoint='', direction='push', compression=None):
         """
         Replicates a dataset towards a given endpoint/target (push)
         Replicates a dataset from a given endpoint to a local target (pull)
@@ -89,6 +89,13 @@ class ZFS(object):
         if base_snapshot is not None:
             delta = '-i {0}@{1} '.format(dataset, base_snapshot)
 
+        if compression is not None:
+            compress = '| {0} -c'.format(compression)
+            decompress = '| {0} -cd'.format(compression)
+        else:
+            compress = ''
+            decompress = ''
+
         if endpoint == '':
             # We're replicating to a local target
             command = 'zfs send {0}{1}@{2} | zfs receive -F {3}'
@@ -97,13 +104,13 @@ class ZFS(object):
         else:
             if direction == 'push':
                 # We're replicating to a remove server
-                command = 'zfs send {0}{1}@{2} | mbuffer -q -v 0 -s 128k -m 512M | {3} \'mbuffer -s 128k -m 512M | zfs receive -F {4}\''
-                command = command.format(delta, dataset, last_snapshot, endpoint, target)
+                command = 'zfs send {0}{1}@{2} {5} | mbuffer -q -v 0 -s 128k -m 512M | {3} \'mbuffer -s 128k -m 512M {6} | zfs receive -F {4}\''
+                command = command.format(delta, dataset, last_snapshot, endpoint, target, compress, decompress)
                 Helper.run_command(command, '/')
             elif direction == 'pull':
                 # We're pulling from a remove server
-                command = '{3} \'zfs send {0}{1}@{2} | mbuffer -q -v 0 -s 128k -m 512M\' | mbuffer -s 128k -m 512M | zfs receive -F {4}'
-                command = command.format(delta, dataset, last_snapshot, endpoint, target)
+                command = '{3} \'zfs send {0}{1}@{2} {5} | mbuffer -q -v 0 -s 128k -m 512M\' | mbuffer -s 128k -m 512M {6} | zfs receive -F {4}'
+                command = command.format(delta, dataset, last_snapshot, endpoint, target, compress, decompress)
                 Helper.run_command(command, '/')
 
     @staticmethod

--- a/scripts/zfs.py
+++ b/scripts/zfs.py
@@ -104,13 +104,13 @@ class ZFS(object):
         else:
             if direction == 'push':
                 # We're replicating to a remove server
-                command = 'zfs send {0}{1}@{2} {5} | mbuffer -q -v 0 -s 128k -m 512M | {3} \'mbuffer -s 128k -m 512M {6} | zfs receive -F {4}\''
-                command = command.format(delta, dataset, last_snapshot, endpoint, target, compress, decompress)
+                command = 'zfs send {0}{1}@{2} {3} | mbuffer -q -v 0 -s 128k -m 512M | {4} \'mbuffer -s 128k -m 512M {5} | zfs receive -F {6}\''
+                command = command.format(delta, dataset, last_snapshot, compress, endpoint, decompress, target)
                 Helper.run_command(command, '/')
             elif direction == 'pull':
                 # We're pulling from a remove server
-                command = '{3} \'zfs send {0}{1}@{2} {5} | mbuffer -q -v 0 -s 128k -m 512M\' | mbuffer -s 128k -m 512M {6} | zfs receive -F {4}'
-                command = command.format(delta, dataset, last_snapshot, endpoint, target, compress, decompress)
+                command = '{4} \'zfs send {0}{1}@{2} {3} | mbuffer -q -v 0 -s 128k -m 512M\' | mbuffer -s 128k -m 512M {5} | zfs receive -F {6}'
+                command = command.format(delta, dataset, last_snapshot, compress, endpoint, decompress, target)
                 Helper.run_command(command, '/')
 
     @staticmethod


### PR DESCRIPTION
Hi! Firstly, thank you for the excellent software, I'm currently using it in my own setup and it's been great so far.

I'm replicating with some slow upload speeds and find that piping my `send` commands through compression pipelines shaves off quite a bit of time, so this patch adds a `compression` setting that should work with utilities like `xz`, `gzip`, and `bzip2`. Basically, anything that can work with `-c` and `-cd`.

I've done some light testing myself and find that this is working for me, but haven't gone through everything with a fine-toothed comb. This probably warrants some `optdepends` in the PKGBUILD, but wanted to see what your thoughts were there.