### PR TITLE
Stop silencing estimated size output

### DIFF
--- a/scripts/zfs.py
+++ b/scripts/zfs.py
@@ -128,7 +128,7 @@ class ZFS(object):
         else:
             command = '{0} \'zfs send -nv {1}{2}@{3}\''
             command = command.format(endpoint, delta, dataset, last_snapshot)
-        command = '{0} 2>&1 > /dev/null | grep \'total estimated size is\''.format(command)
+        command = '{0} 2>&1 | grep \'total estimated size is\''.format(command)
         output = Helper.run_command(command, '/')
         size = output.strip().split(' ')[-1]
         if size[-1].isdigit():


### PR DESCRIPTION
So, this is a fix I had to make on my server after a ZFS on Linux upgrade. I'm unsure how the original code worked, to be honest, so if there's logic here I'm not aware of, I may be able to figure out the root cause.

I'm not sure what the exact change was after my upgrade that caused the logic to break, but by not redirecting here, my snapshots started working again. It seems like this pipeline logic should work in either case, though.