### PR TITLE
Parameterize mbuffer -m size

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Examples
     replicate_target = zpool/backups/zroot
     schema = 7d3w11m5y
     compression = gzip
+    buffer_size = 256M
 
     [zpool/data]
     mountpoint = /mnt/data
@@ -71,6 +72,7 @@ A summary of the different options:
 * replicate_target: The target to which the snapshots should be send. Should be omitted if no replication is required or a replication_source is specified.
 * replicate_source: The source from which to pull the snapshots to receive onto the local dataset. Should be omitted if no replication is required or a replication_target is specified.
 * compression: Indicates the compression program to pipe remote replicated snapshots through (for use in low-bandwidth setups.) The compression utility should accept standard compression flags (`-c` for standard output, `-d` for decompress.)
+* buffer_size: Controls the amount of memory that `mbuffer` will allocate on either side of the send/receive pipeline. Is passed directly to the `-m` parameter of `mbuffer`. Defaults to `512M`.
 * schema: In case the snapshots should be cleaned, this is the schema the manager will use to clean.
 * preexec: A command that will be executed, before snapshot/replication. Should be omitted if nothing should be executed
 * postexec: A command that will be executed, after snapshot/replication,  but before the cleanup. Should be omitted if nothing should be executed

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -35,6 +35,9 @@ from clean import Cleaner
 from helper import Helper
 
 
+BUFFER_SIZE = '512M' # Default -m value to pass to mbuffer
+
+
 class Manager(object):
     """
     Manages the ZFS snapshotting process
@@ -137,7 +140,7 @@ class Manager(object):
                                             # There is a snapshot on this host that is not yet on the other side.
                                             size = ZFS.get_size(dataset, previous_snapshot, snapshot)
                                             Manager.logger.info('  {0}@{1} > {0}@{2} ({3})'.format(dataset, previous_snapshot, snapshot, size))
-                                            ZFS.replicate(dataset, previous_snapshot, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
+                                            ZFS.replicate(dataset, previous_snapshot, snapshot, remote_dataset, replicate_settings.get('buffer_size', BUFFER_SIZE), replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'])
                                             ZFS.hold(dataset, snapshot)
                                             ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                                             ZFS.release(dataset, previous_snapshot)
@@ -152,7 +155,7 @@ class Manager(object):
                                             # There is a remote snapshot that is not yet on the local host.
                                             size = ZFS.get_size(remote_dataset, previous_snapshot, snapshot, replicate_settings['endpoint'])
                                             Manager.logger.info('  {0}@{1} > {0}@{2} ({3})'.format(remote_dataset, previous_snapshot, snapshot, size))
-                                            ZFS.replicate(remote_dataset, previous_snapshot, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
+                                            ZFS.replicate(remote_dataset, previous_snapshot, snapshot, dataset, replicate_settings.get('buffer_size', BUFFER_SIZE), replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'])
                                             ZFS.hold(dataset, snapshot)
                                             ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                                             ZFS.release(dataset, previous_snapshot)
@@ -165,7 +168,7 @@ class Manager(object):
                                     snapshot = local_snapshots[-1]
                                     size = ZFS.get_size(dataset, None, snapshot)
                                     Manager.logger.info('  {0}@         > {0}@{1} ({2})'.format(dataset, snapshot, size))
-                                    ZFS.replicate(dataset, None, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
+                                    ZFS.replicate(dataset, None, snapshot, remote_dataset, replicate_settings.get('buffer_size', BUFFER_SIZE), replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'])
                                     ZFS.hold(dataset, snapshot)
                                     ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                             elif push is False and remote_dataset in remote_snapshots and len(remote_snapshots[remote_dataset]) > 0:
@@ -175,7 +178,7 @@ class Manager(object):
                                     snapshot = remote_snapshots[remote_dataset][-1]
                                     size = ZFS.get_size(remote_dataset, None, snapshot, replicate_settings['endpoint'])
                                     Manager.logger.info('  {0}@         > {0}@{1} ({2})'.format(remote_dataset, snapshot, size))
-                                    ZFS.replicate(remote_dataset, None, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
+                                    ZFS.replicate(remote_dataset, None, snapshot, dataset, replicate_settings.get('buffer_size', BUFFER_SIZE), replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'])
                                     ZFS.hold(dataset, snapshot)
                                     ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                             Manager.logger.info('Replicating {0} complete'.format(dataset))

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -137,7 +137,7 @@ class Manager(object):
                                             # There is a snapshot on this host that is not yet on the other side.
                                             size = ZFS.get_size(dataset, previous_snapshot, snapshot)
                                             Manager.logger.info('  {0}@{1} > {0}@{2} ({3})'.format(dataset, previous_snapshot, snapshot, size))
-                                            ZFS.replicate(dataset, previous_snapshot, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'])
+                                            ZFS.replicate(dataset, previous_snapshot, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
                                             ZFS.hold(dataset, snapshot)
                                             ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                                             ZFS.release(dataset, previous_snapshot)
@@ -152,7 +152,7 @@ class Manager(object):
                                             # There is a remote snapshot that is not yet on the local host.
                                             size = ZFS.get_size(remote_dataset, previous_snapshot, snapshot, replicate_settings['endpoint'])
                                             Manager.logger.info('  {0}@{1} > {0}@{2} ({3})'.format(remote_dataset, previous_snapshot, snapshot, size))
-                                            ZFS.replicate(remote_dataset, previous_snapshot, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'])
+                                            ZFS.replicate(remote_dataset, previous_snapshot, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
                                             ZFS.hold(dataset, snapshot)
                                             ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                                             ZFS.release(dataset, previous_snapshot)
@@ -165,7 +165,7 @@ class Manager(object):
                                     snapshot = local_snapshots[-1]
                                     size = ZFS.get_size(dataset, None, snapshot)
                                     Manager.logger.info('  {0}@         > {0}@{1} ({2})'.format(dataset, snapshot, size))
-                                    ZFS.replicate(dataset, None, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'])
+                                    ZFS.replicate(dataset, None, snapshot, remote_dataset, replicate_settings['endpoint'], direction='push', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
                                     ZFS.hold(dataset, snapshot)
                                     ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                             elif push is False and remote_dataset in remote_snapshots and len(remote_snapshots[remote_dataset]) > 0:
@@ -175,7 +175,7 @@ class Manager(object):
                                     snapshot = remote_snapshots[remote_dataset][-1]
                                     size = ZFS.get_size(remote_dataset, None, snapshot, replicate_settings['endpoint'])
                                     Manager.logger.info('  {0}@         > {0}@{1} ({2})'.format(remote_dataset, snapshot, size))
-                                    ZFS.replicate(remote_dataset, None, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'])
+                                    ZFS.replicate(remote_dataset, None, snapshot, dataset, replicate_settings['endpoint'], direction='pull', compression=replicate_settings['compression'], buffer_size=replicate_settings['buffer_size'])
                                     ZFS.hold(dataset, snapshot)
                                     ZFS.hold(remote_dataset, snapshot, replicate_settings['endpoint'])
                             Manager.logger.info('Replicating {0} complete'.format(dataset))

--- a/scripts/zfs.py
+++ b/scripts/zfs.py
@@ -79,7 +79,7 @@ class ZFS(object):
         Helper.run_command(command, '/')
 
     @staticmethod
-    def replicate(dataset, base_snapshot, last_snapshot, target, endpoint='', direction='push', compression=None):
+    def replicate(dataset, base_snapshot, last_snapshot, target, endpoint='', direction='push', compression=None, buffer_size='512M'):
         """
         Replicates a dataset towards a given endpoint/target (push)
         Replicates a dataset from a given endpoint to a local target (pull)
@@ -104,13 +104,13 @@ class ZFS(object):
         else:
             if direction == 'push':
                 # We're replicating to a remote server
-                command = 'zfs send {0}{1}@{2} {3} | mbuffer -q -v 0 -s 128k -m 512M | {4} \'mbuffer -s 128k -m 512M {5} | zfs receive -F {6}\''
-                command = command.format(delta, dataset, last_snapshot, compress, endpoint, decompress, target)
+                command = 'zfs send {0}{1}@{2} {3} | mbuffer -q -v 0 -s 128k -m {4} | {5} \'mbuffer -s 128k -m {4} {6} | zfs receive -F {7}\''
+                command = command.format(delta, dataset, last_snapshot, compress, buffer_size, endpoint, decompress, target)
                 Helper.run_command(command, '/')
             elif direction == 'pull':
                 # We're pulling from a remote server
-                command = '{4} \'zfs send {0}{1}@{2} {3} | mbuffer -q -v 0 -s 128k -m 512M\' | mbuffer -s 128k -m 512M {5} | zfs receive -F {6}'
-                command = command.format(delta, dataset, last_snapshot, compress, endpoint, decompress, target)
+                command = '{5} \'zfs send {0}{1}@{2} {3} | mbuffer -q -v 0 -s 128k -m {4}\' | mbuffer -s 128k -m {4} {6} | zfs receive -F {7}'
+                command = command.format(delta, dataset, last_snapshot, compress, buffer_size, endpoint, decompress, target)
                 Helper.run_command(command, '/')
 
     @staticmethod

--- a/scripts/zfs.py
+++ b/scripts/zfs.py
@@ -79,7 +79,7 @@ class ZFS(object):
         Helper.run_command(command, '/')
 
     @staticmethod
-    def replicate(dataset, base_snapshot, last_snapshot, target, endpoint='', direction='push', compression=None, buffer_size='512M'):
+    def replicate(dataset, base_snapshot, last_snapshot, target, buffer_size, endpoint='', direction='push', compression=None):
         """
         Replicates a dataset towards a given endpoint/target (push)
         Replicates a dataset from a given endpoint to a local target (pull)


### PR DESCRIPTION
There are some cases in which it's nice to be able to set the `mbuffer` memory allocation for over/undersized target hosts. This just makes it a configurable parameter with defaults that stick with what was already being used.