### PR TITLE
Fix cleanup for remotes with snapshots from yesterday

### DIFF
--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -28,7 +28,7 @@ import time
 import os
 import logging
 import logging.handlers
-from datetime import datetime
+from datetime import datetime,timedelta
 
 from zfs import ZFS
 from clean import Cleaner
@@ -66,7 +66,9 @@ class Manager(object):
         """
 
         now = datetime.now()
+        yda = datetime.now() - timedelta(1)
         today = '{0:04d}{1:02d}{2:02d}'.format(now.year, now.month, now.day)
+        yesterday = '{0:04d}{1:02d}{2:02d}'.format(yda.year, yda.month, yda.day)
 
         snapshots = ZFS.get_snapshots()
         datasets = ZFS.get_datasets()
@@ -185,7 +187,7 @@ class Manager(object):
                             Helper.run_command(dataset_settings['postexec'], '/')
 
                     # Cleaning the snapshots (cleaning is mandatory)
-                    if today in local_snapshots:
+                    if today in local_snapshots or yesterday in local_snapshots:
                         Cleaner.clean(dataset, local_snapshots, dataset_settings['schema'])
 
                 except Exception as ex:


### PR DESCRIPTION
I ran into a problem where snapshots were not cleaned as only remote snapshots where pulled from a remote host and those were a bit too old to fit into the today check. To circumvent that i extended the check to include yesterday - the cleanup is handled by the schema anyway so it's just the condition to trigger the cleanup that is affected. That way i get my snapshots cleaned up and still the manager does not clean snapshots of no longer active replications which, i think, was the reason for this check in the first place.