### PR TITLE
Recursively delete snapshots

### DIFF
--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -36,7 +36,7 @@ class Cleaner(object):
     logger = None  # The manager will fill this object
 
     @staticmethod
-    def clean(dataset, snapshots, schema):
+    def clean(dataset, snapshots, schema, recursive):
         today = datetime.now()
 
         # Parsing schema
@@ -118,10 +118,10 @@ class Cleaner(object):
         for key in keys:
             for snapshot in to_delete[key]:
                 Cleaner.logger.info('  Destroying {0}@{1}'.format(dataset, snapshot['name']))
-                ZFS.destroy(dataset, snapshot['name'])
+                ZFS.destroy(dataset, snapshot['name'], recursive)
         for snapshot in end_of_life_snapshots:
             Cleaner.logger.info('  Destroying {0}@{1}'.format(dataset, snapshot['name']))
-            ZFS.destroy(dataset, snapshot['name'])
+            ZFS.destroy(dataset, snapshot['name'], recursive)
 
         if will_delete is True:
             Cleaner.logger.info('Cleaning {0} complete'.format(dataset))

--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -191,7 +191,7 @@ class Manager(object):
 
                     # Cleaning the snapshots (cleaning is mandatory)
                     if today in local_snapshots or yesterday in local_snapshots:
-                        Cleaner.clean(dataset, local_snapshots, dataset_settings['schema'])
+                        Cleaner.clean(dataset, local_snapshots, dataset_settings['schema'], dataset_settings['recursive'])
 
                 except Exception as ex:
                     Manager.logger.error('Exception: {0}'.format(str(ex)))

--- a/scripts/zfs.py
+++ b/scripts/zfs.py
@@ -162,10 +162,10 @@ class ZFS(object):
         return '{0}iB'.format(size)
 
     @staticmethod
-    def destroy(dataset, snapshot):
+    def destroy(dataset, snapshot, recursive):
         """
         Destroyes a dataset
         """
 
-        command = 'zfs destroy {0}@{1}'.format(dataset, snapshot)
+        command = 'zfs destroy {2} {0}@{1}'.format(dataset, snapshot, "-r" if recursive else "")
         Helper.run_command(command, '/')


### PR DESCRIPTION
If snapshots are created recursively, also delete them recursively.

Does not apply retroactively, any snapshots that were left behind will remain. It might be possible to make it apply retroactively by finding all children and checking them against the schema, if that's wanted I could probably get around to it someday (tm).